### PR TITLE
SSL setup tweaks

### DIFF
--- a/django_cpserver/management/commands/runcpserver.py
+++ b/django_cpserver/management/commands/runcpserver.py
@@ -162,7 +162,8 @@ def start_server(options):
         (options['host'], int(options['port'])),
         WSGIHandler(), 
         int(options['threads']), 
-        options['server_name']
+        options['server_name'],
+        timeout=options['timeout']
     )
 
     if cherrypy.__version__ >= '3.2.0':

--- a/django_cpserver/management/commands/runcpserver.py
+++ b/django_cpserver/management/commands/runcpserver.py
@@ -25,6 +25,7 @@ Optional CherryPy server settings: (setting=value)
   threads=NUMBER        Number of threads for server to use
   ssl_certificate=FILE  SSL certificate file
   ssl_private_key=FILE  SSL private key file
+  ssl_certificate_chain=FILE	SSL root CA certificate file
   server_user=STRING    user to run daemonized process
                         Defaults to www-data
   server_group=STRING   group to daemonized process
@@ -54,6 +55,7 @@ CPSERVER_OPTIONS = {
 'server_group': 'www-data',
 'ssl_certificate': None,
 'ssl_private_key': None,
+'ssl_certificate_chain': None,
 }
 
 
@@ -162,6 +164,8 @@ def start_server(options):
     if options['ssl_certificate'] and options['ssl_private_key']:
         server.ssl_certificate = options['ssl_certificate']
         server.ssl_private_key = options['ssl_private_key']  
+        if options['ssl_certificate_chain']:
+            server.ssl_certificate_chain = options['ssl_certificate_chain']
     try:
         server.start()
     except KeyboardInterrupt:

--- a/django_cpserver/management/commands/runcpserver.py
+++ b/django_cpserver/management/commands/runcpserver.py
@@ -163,7 +163,7 @@ def start_server(options):
         WSGIHandler(), 
         int(options['threads']), 
         options['server_name'],
-        timeout=options['timeout']
+        timeout=int(options['timeout'])
     )
 
     if cherrypy.__version__ >= '3.2.0':

--- a/django_cpserver/management/commands/runcpserver.py
+++ b/django_cpserver/management/commands/runcpserver.py
@@ -24,6 +24,7 @@ Optional CherryPy server settings: (setting=value)
   pidfile=FILE          write the spawned process-id to this file
   workdir=DIRECTORY     change to this directory when daemonizing
   threads=NUMBER        Number of threads for server to use
+  timeout=NUMBER        Timeout (in seconds) for accepted connections
   ssl_certificate=FILE  SSL certificate file
   ssl_private_key=FILE  SSL private key file
   ssl_certificate_chain=FILE	SSL root CA certificate file
@@ -49,6 +50,7 @@ CPSERVER_OPTIONS = {
 'port': 8088,
 'server_name': 'localhost',
 'threads': 10, 
+'timeout': 10, 
 'daemonize': False,
 'workdir': None,
 'pidfile': None,


### PR DESCRIPTION
I realize that this repo hasn't seen much activity (given that it's such a straightforward and useful management command), however, I updated the management command to use a later cherrypy ssl setup mechanism.  

I added  a check for cherrypy versions to retain compatibility for those who are pre 3.2.

Additionally, I added the option to use the ssl_certificate_chain to both older and newer implementations of cherrypy.  
