### PR TITLE
Python 3 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-*.pyc
-*~
-.DS_Store
-local_settings.py

--- a/README.rst
+++ b/README.rst
@@ -21,3 +21,9 @@ Acknowledgements
 Idea and code snippets borrowed from `Loic d'Anterroches`__, adapted to run as a management command
 
 __ http://www.xhtml.net/scripts/Django-CherryPy-server-DjangoCerise
+
+Modifications
+=============
+
+This version is mantained by Manuel Naranjo < manuel at aircable dot net > mail
+him for modifications questions.

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,16 @@ Usage
 
 Run ``./manage.py runcpserver help`` from within your project directory
 
+Apache and mod_proxy
+====================
+By default runcpserver binds to localhost on port 8088. Another webserver can be used to expose your local CherryPy
+instance by proxying requests to the local process. Remember, runcpserver won't serve your static files.
+
+<Location /django>
+  ProxyPass http://localhost:8088
+  ProxyPassRevese http://localhost:8088
+</Location>
+
 Acknowledgements
 ================
 

--- a/README.rst
+++ b/README.rst
@@ -16,14 +16,17 @@ Usage
 Run ``./manage.py runcpserver help`` from within your project directory
 
 Apache and mod_proxy
-====================
+--------------------
 By default runcpserver binds to localhost on port 8088. Another webserver can be used to expose your local CherryPy
 instance by proxying requests to the local process. Remember, runcpserver won't serve your static files.
 
-<Location /django>
-  ProxyPass http://localhost:8088
-  ProxyPassRevese http://localhost:8088
-</Location>
+
+    ProxyPass /static/ !  
+    <Location /django>
+      ProxyPass http://localhost:8088
+      ProxyPassRevese http://localhost:8088
+    </Location>
+
 
 Acknowledgements
 ================

--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,3 @@ Acknowledgements
 Idea and code snippets borrowed from `Loic d'Anterroches`__, adapted to run as a management command
 
 __ http://www.xhtml.net/scripts/Django-CherryPy-server-DjangoCerise
-
-Modifications
-=============
-
-This version is mantained by Manuel Naranjo < manuel at aircable dot net > mail
-him for modifications questions.

--- a/django_cpserver/management/commands/runcpserver.py
+++ b/django_cpserver/management/commands/runcpserver.py
@@ -153,9 +153,11 @@ def start_server(options):
     
     from cherrypy.wsgiserver import CherryPyWSGIServer as Server
     from django.core.handlers.wsgi import WSGIHandler
+    from django.core.servers.basehttp import AdminMediaHandler
+    app = AdminMediaHandler(WSGIHandler())
     server = Server(
         (options['host'], int(options['port'])),
-        WSGIHandler(), 
+        app, 
         int(options['threads']), 
         options['server_name']
     )

--- a/django_cpserver/management/commands/runcpserver.py
+++ b/django_cpserver/management/commands/runcpserver.py
@@ -159,7 +159,9 @@ def start_server(options):
         (options['host'], int(options['port'])),
         app, 
         int(options['threads']), 
-        options['server_name']
+        options['server_name'],
+        timeout=2,
+        shutdown_timeout=2
     )
     if options['ssl_certificate'] and options['ssl_private_key']:
         server.ssl_certificate = options['ssl_certificate']

--- a/django_cpserver/management/commands/runcpserver.py
+++ b/django_cpserver/management/commands/runcpserver.py
@@ -115,7 +115,8 @@ def poll_process(pid):
         try:
             # poll the process state
             os.kill(pid, 0)
-        except OSError, e:
+        except OSError:
+            e = sys.exc_info()[1]
             if e[0] == errno.ESRCH:
                 # process has died
                 return False

--- a/django_cpserver/management/commands/runcpserver.py
+++ b/django_cpserver/management/commands/runcpserver.py
@@ -181,7 +181,7 @@ def runcpserver(argset=[], **kwargs):
         options[k.lower()] = v
     
     if "help" in options:
-        print CPSERVER_HELP
+        print(CPSERVER_HELP)
         return
         
     if "stop" in options:
@@ -204,7 +204,7 @@ def runcpserver(argset=[], **kwargs):
         fp.close()
     
     # Start the webserver
-    print 'starting server with options %s' % options
+    print('starting server with options %s' % options)
     start_server(options)
 
 

--- a/django_cpserver/management/commands/runcpserver.py
+++ b/django_cpserver/management/commands/runcpserver.py
@@ -154,8 +154,7 @@ def start_server(options):
     
     from cherrypy.wsgiserver import CherryPyWSGIServer as Server
     from django.core.handlers.wsgi import WSGIHandler
-    from django.core.servers.basehttp import AdminMediaHandler
-    app = AdminMediaHandler(WSGIHandler())
+    app = WSGIHandler()
     server = Server(
         (options['host'], int(options['port'])),
         app, 

--- a/django_cpserver/management/commands/runcpserver.py
+++ b/django_cpserver/management/commands/runcpserver.py
@@ -140,7 +140,7 @@ def stop_server(pidfile):
             #process didn't exit cleanly, make one last effort to kill it
             os.kill(pid, signal.SIGKILL)
             if poll_process(pid):
-                raise OSError, "Process %s did not stop."
+                raise OSError("Process %s did not stop.")
         os.remove(pidfile)
 
 def start_server(options):

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,12 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
-    name="django-cpserver",
+    name="django-cpserver-op",
     version="1.2",
-    description="Management commands for serving Django via CherryPy's built-in WSGI server",
+    description="Management commands for serving Django via CherryPy's built-in WSGI server modified for OpenProximity",
     author="Peter Baumgartner",
     author_email="pete@lincolnloop.com",
-    url="https://github.com/manuelnaranjo/django-cpserver",
+    url="https://github.com/OpenProximity/django-cpserver",
     packages=[
         "django_cpserver",
         "django_cpserver.management",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 setup(
     name="django-cpserver-op",
-    version="1.2.1",
+    version="1.2.2",
     description="Management commands for serving Django via CherryPy's built-in WSGI server modified for OpenProximity",
     author="Peter Baumgartner",
     author_email="pete@lincolnloop.com",

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,13 @@ setup(
         "django_cpserver.management.commands",
     ],
     license="BSD",
-    long_description=read("README.rst")
+    long_description=read("README.rst"),
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Framework :: CherryPy",
+        "Framework :: Django",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python",
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 setup(
     name="django-cpserver-op",
-    version="1.2",
+    version="1.2.1",
     description="Management commands for serving Django via CherryPy's built-in WSGI server modified for OpenProximity",
     author="Peter Baumgartner",
     author_email="pete@lincolnloop.com",
@@ -19,6 +19,7 @@ setup(
     ],
     license="BSD",
     long_description=read("README.rst"),
+    install_requires=['CherryPy'],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: CherryPy",

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,22 @@
-from distutils.core import setup
- 
+#from distutils.core import setup
+from setuptools import setup
+import os, os.path
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
 setup(
     name="django_cpserver",
-    version="0.1",
+    version="0.2",
     description="Management commands for serving Django via CherryPy's built-in WSGI server",
     author="Peter Baumgartner",
     author_email="pete@lincolnloop.com",
-    url="http://lincolnloop.com/blog/2008/mar/25/serving-django-cherrypy/",
+    url="https://github.com/manuelnaranjo/django-cpserver",
     packages=[
         "django_cpserver",
         "django_cpserver.management",
         "django_cpserver.management.commands",
     ],
+    license="BSD",
+    long_description=read("README.rst")
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 setup(
     name="django-cpserver-op",
-    version="1.2.2",
+    version="1.90.0",
     description="Management commands for serving Django via CherryPy's built-in WSGI server modified for OpenProximity",
     author="Peter Baumgartner",
     author_email="pete@lincolnloop.com",

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
-    name="django_cpserver",
-    version="0.2",
+    name="django-cpserver",
+    version="1.2",
     description="Management commands for serving Django via CherryPy's built-in WSGI server",
     author="Peter Baumgartner",
     author_email="pete@lincolnloop.com",


### PR DESCRIPTION
These small changes allow django-cpserver to run on Python 3 (tested with 3.3.2). Changes should be backwards compatible with the most recent releases of Python 2.6.
